### PR TITLE
[balancer spot price] include swap fee in calculation

### DIFF
--- a/src/Accounting/index.ts
+++ b/src/Accounting/index.ts
@@ -263,7 +263,12 @@ export const calcBptTokenSpotPrice: (
     buyingToken: {
         weight: BigNumber,
         balance: BigNumber
-    }
-) => BigNumber = (sellingToken, buyingToken) => (
-    (sellingToken.balance.div(sellingToken.weight)).div((buyingToken.balance).div(buyingToken.weight))
-)
+    },
+    swapFee: BigNumber
+) => BigNumber = (sellingToken, buyingToken, swapFee) => {
+    const numerator = sellingToken.balance.div(sellingToken.weight);
+    const denominator = buyingToken.balance.div(buyingToken.weight);
+    const swapFeeMultiplier = new BigNumber(1).div(new BigNumber(1).minus(swapFee))
+
+    return (numerator.div(denominator)).times(swapFeeMultiplier);
+}


### PR DESCRIPTION
# Motivation
The spot price calculations did not include the swap fee so it was off by a small amount

# Changes
Add a third argument `swapFee` to balancer spot pricing function and update calculation to match https://dev.balancer.fi/resources/pool-interfacing/pool-math/weighted-math#spot-price-with-swap-fees